### PR TITLE
fix: fix pull_request types filter

### DIFF
--- a/pkg/handler/lambda/match.go
+++ b/pkg/handler/lambda/match.go
@@ -87,10 +87,6 @@ func (handler *Handler) matchEventType(matchConfig *config.MatchConfig, event *E
 		if ev.Name != event.Type {
 			continue
 		}
-		// TODO
-		// https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request
-		// > By default, a workflow only runs when a pull_request event's activity type is
-		// > opened, synchronize, or reopened.
 		if len(ev.Types) == 0 {
 			return true, nil, nil
 		}


### PR DESCRIPTION
Close #28

https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request

> By default, a workflow only runs when a pull_request event's activity type is
> opened, synchronize, or reopened.